### PR TITLE
Enable CI build automation via edgeXBuildGoApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ stage/
 parts/
 squashfs-root/
 coverage.out
+VERSION

--- a/Attribution.txt
+++ b/Attribution.txt
@@ -87,3 +87,9 @@ https://github.com/ugorji/go/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE
+
+jessevdk/go-flags (BSD-3) https://github.com/jessevdk/go-flags
+https://github.com/jessevdk/go-flags/blob/master/LICENSE

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -15,37 +15,20 @@
 #
 
 ARG BASE=golang:1.12-alpine
-FROM ${BASE} AS builder
+FROM ${BASE}
 
-ARG MAKE='make build'
 ARG ALPINE_PKG_BASE="make git"
 ARG ALPINE_PKG_EXTRA=""
-
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
-RUN apk add --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
-
-WORKDIR $GOPATH/src/github.com/edgexfoundry/device-rest-go
-
-COPY go.mod .
-COPY Makefile .
-
-RUN make update
-
-COPY . .
-
-RUN $MAKE
-
-FROM alpine:latest
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2019: Intel'
 
-LABEL Name=device-rest-go Version=${VERSION}
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-COPY --from=builder /go/src/github.com/edgexfoundry/device-rest-go/Attribution.txt /
-COPY --from=builder /go/src/github.com/edgexfoundry/device-rest-go/LICENSE /
-COPY --from=builder /go/src/github.com/edgexfoundry/device-rest-go/cmd /
+RUN apk add --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
 
-EXPOSE 49986
+WORKDIR /device-rest-go
 
-CMD ["/device-rest-go","--registry=consul://edgex-core-consul:8500","--profile=docker","--confdir=/res"]
+COPY . .
+
+RUN go mod download

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2019-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+edgeXBuildGoApp (
+    project: 'device-rest-go',
+    goVersion: '1.12'
+)

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ test:
 clean:
 	rm -f $(MICROSERVICES)
 
+update:
+	$(GO) mod download
+
 docker: $(DOCKERS)
 
 docker_device_rest_go:


### PR DESCRIPTION
For consistency sake, the build pattern was modeled after device-snmp-go: 
https://github.com/edgexfoundry/device-snmp-go/pull/41

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>