### PR TITLE
fix: Update to latest release of SDK V1.1.2 for mediaType fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-rest-go
 go 1.12
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20191216171425-0749bf2bbbaf
+	github.com/edgexfoundry/device-sdk-go v1.1.2
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.36
 	github.com/gorilla/mux v1.6.2
 	github.com/spf13/cast v1.3.0


### PR DESCRIPTION
Device SDK V1.1.2 fixed bug for mediaType not being marshaled 

closes #10 