### PR TITLE
refactor: Set default logging level to INFO

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -1,5 +1,5 @@
 [Writable]
-LogLevel = 'DEBUG'
+LogLevel = 'INFO'
 
 [Service]
 BootTimeout = 30000


### PR DESCRIPTION
Default log level not set to INFO

closes #21
