### PR TITLE
update device-sdk-go: 1.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-rest-go
 go 1.13
 
 require (
-	github.com/edgexfoundry/device-sdk-go v1.2.1
+	github.com/edgexfoundry/device-sdk-go v1.2.2
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.58
 	github.com/gorilla/mux v1.7.1
 	github.com/spf13/cast v1.3.0


### PR DESCRIPTION
Update the service to use device-sdk-go v1.2.2 as part of the maintenance release of Geneva. This version of the SDK includes:

 * a fix for a timing issue w/consul which impacted startup time
 * ensure services listen on all network interfaces
