### PR TITLE
docs: Add standard PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## PR Checklist
+Please check if your PR fulfills the following requirements:
+
+- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+## PR Type
+What kind of change does this PR introduce?
+<!-- Please check the one that applies to this PR using "x". -->
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Other... Please describe:
+
+
+## What is the current behavior?
+<!-- Please describe the current behavior and link to a relevant issue. -->
+
+Issue Number:
+
+
+## What is the new behavior?
+
+
+## Does this PR introduce a breaking change?
+<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
+
+- [ ] Yes
+- [ ] No
+
+## Are there any new imports or modules? If so, what are they used for and why?
+
+
+## Are there any specific instructions or things that should be known prior to reviewing?
+
+## Other information


### PR DESCRIPTION
Signed-off-by: James Gregg <james.r.gregg@intel.com>

Template includes the question for added dependencies as per Architect's meeting 06/15/2020
- Add standard PR template 
