### PR TITLE
fix(snap): Update snap versioning logic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,7 @@
 name: edgex-device-rest
 base: core18
 type: app
-version: "replace-me"
-version-script: |
-  VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
-  echo $VERSION-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
-
+adopt-info: version
 license: Apache-2.0
 title: EdgeX REST Device Service
 summary: EdgeX device service for REST protocol
@@ -38,6 +34,17 @@ apps:
     plugs: [network, network-bind]
 
 parts:
+  version:
+    plugin: nil
+    source: snap/local
+    override-pull: |
+      cd $SNAPCRAFT_PROJECT_DIR
+      if [ -f VERSION ]; then
+        PROJECT_VERSION=$(cat VERSION)
+      else
+        PROJECT_VERSION="0.0.0"
+      fi
+      snapcraftctl set-version ${PROJECT_VERSION}
   go:
     plugin: nil
     source: snap/local


### PR DESCRIPTION
This fix contains three minor changes to the way version numbers are
generated when building the snap:

1) Remove git tag and datestamp from the version number.
("1.1.3-dev.5" vs "1.1.3-dev.4-20201021+856f4f8")
2) Use "snapcraftctl set-version" instead of deprecated "version-script"
3) Use "cat" instead of "shell cat", to correctly locate the VERSION file.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The snap version is in the format "1.1.3-dev.4-20201021+856f4f8"

Issue Number:


## What is the new behavior?
The snap version will be in the format "1.1.3-dev.4"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information