### PR TITLE
feat(snap): add startup-duration and startup-interval configure options

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,33 @@
+# EdgeX REST Device Service Snap
+[![snap store badge](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-black-uneditable.png)](https://snapcraft.io/edgex-device-rest)
+
+This folder contains snap packaging for the EdgeX REST Protocol Device Service Snap
+
+The snap currently supports both `amd64` and `arm64` platforms.
+
+
+## Snap configuration
+
+Device services implement a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to active state.
+
+Snapd doesn't support orchestration between services in different snaps. It is therefore possible on a reboot for a device service to come up faster than all of the required services running in the main edgexfoundry snap. If this happens, it's possible that the device service repeatedly fails startup, and if it exceeds the systemd default limits, then it might be left in a failed state. This situation might be more likely on constrained hardware (e.g. RPi).
+
+This snap therefore implements a basic retry loop with a maximum duration and sleep interval. If the dependent services are not available, the service sleeps for the defined interval (default: 1s) and then tries again up to a maximum duration (default: 60s). These values can be overridden with the following commands:
+    
+To change the maximum duration, use the following command:
+
+```bash
+$ sudo snap set edgex-device-rest startup-duration=60
+```
+
+To change the interval between retries, use the following command:
+
+```bash
+$ sudo snap set edgex-device-rest startup-interval=1
+```
+
+To apply the settings, the service should then be restarted as follows:
+
+```bash
+$ sudo snap restart edgex-device-rest.device-rest-go
+```

--- a/snap/local/runtime-helpers/bin/startup-env-var.sh
+++ b/snap/local/runtime-helpers/bin/startup-env-var.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+EDGEX_STARTUP_DURATION=$(snapctl get startup-duration)
+
+if [ -n "$EDGEX_STARTUP_DURATION" ]; then
+  export EDGEX_STARTUP_DURATION
+fi
+
+EDGEX_STARTUP_INTERVAL=$(snapctl get startup-interval)
+
+if [ -n "$EDGEX_STARTUP_INTERVAL" ]; then
+  export EDGEX_STARTUP_INTERVAL
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ apps:
   device-rest-go:
     adapter: none
     command: bin/device-rest-go $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
+    command-chain:
+      - bin/startup-env-var.sh
     daemon: simple
     environment:
       CONFIG_PRO_ARG: "--cp=consul://localhost:8500"
@@ -106,3 +108,7 @@ parts:
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-rest-go/Attribution.txt"
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-rest-go/LICENSE"
+
+  config-common:
+    plugin: dump
+    source: snap/local/runtime-helpers


### PR DESCRIPTION
To change the default startup duration use:
sudo snap set edgex-device-rest startup-duration=n

To change the default startup interval use:
sudo snap set edgex-device-rest startup-interval=n

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The module go-mod-bootstrap implements a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to active state.

The logic implements a basic retry loop with a maximum duration and sleep interval. If the dependent services are not available, the service sleeps for the defined interval (default: 1s) and then tries again up to a maximum duration (default: 60s). These values can be overridden via environment variables.

Issue Number:
N/A

## What is the new behavior?
This PR covers updating all the device service snap to allow these variables to be set/queried via the configure hook.

To change the default startup duration use:
sudo snap set edgex-device-rest startup-duration=n

To change the default startup interval use:
sudo snap set edgex-device-rest startup-interval=n



## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
N/A

## Are there any specific instructions or things that should be known prior to reviewing?
N/A
## Other information
N/A