### PR TITLE
refactor: Update for new service key names and overrides for hyphen to underscore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 
 .idea/
 vendor/
-cmd/device-rest-go
+cmd/device-rest
 glide.lock
 go.sum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /device-rest-go
 
 COPY . .
 
+RUN go mod tidy
 RUN make update
 
 RUN $MAKE

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,5 @@ COPY --from=builder /device-rest-go/Attribution.txt /
 
 EXPOSE 49986
 
-ENTRYPOINT ["/device-rest-go"]
+ENTRYPOINT ["/device-rest"]
 CMD ["--cp=consul://edgex-core-consul:8500", "--confdir=/res", "--registry"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GO=CGO_ENABLED=0 GO111MODULE=on go
 GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 
-MICROSERVICES=cmd/device-rest-go
+MICROSERVICES=cmd/device-rest
 
 .PHONY: $(MICROSERVICES)
 
@@ -17,7 +17,7 @@ GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-rest-go.Version=$(VERSION)"
 
 build: $(MICROSERVICES)
 
-cmd/device-rest-go:
+cmd/device-rest:
 	go mod tidy
 	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cmd/device-rest:
 	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd
 
 test:
+	go mod tidy
 	$(GOCGO) test -coverprofile=coverage.out ./...
 	$(GOCGO) vet ./...
 	gofmt -l .

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	serviceName string = "edgex-device-rest"
+	serviceName string = "device-rest"
 )
 
 func main() {

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -29,12 +29,12 @@ Port = 8500
 Type = 'consul'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48080
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48081
@@ -63,11 +63,11 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/edgex-device-rest/'
+Path = '/v1/secret/edgex/device-rest/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
-TokenFile = '/tmp/edgex/secrets/edgex-device-rest/secrets-token.json'
+TokenFile = '/tmp/edgex/secrets/device-rest/secrets-token.json'
 AdditionalRetryAttempts = 10
 RetryWaitPeriod = "1s"
   [SecretStore.Authentication]

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,9 @@ module github.com/edgexfoundry/device-rest-go
 go 1.16
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.58
+	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.63
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.7.0
 )
-
-replace github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.16
 
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.58
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.83
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go


### PR DESCRIPTION
**Dependent on edgexfoundry/device-sdk-go#926**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Service key constants have the edgex- prefix


## Issue Number:  #98


## What is the new behavior?
Service key constants no longer have the edgex- prefix
Hyphen in Overrides are converted to underscore

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No
- [ ] 
BREAKING CHANGE: Service key names used in configuration have changed.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
