### PR TITLE
refactor: Update to assign and uses new Port Assignments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=builder /device-rest-go/cmd /
 COPY --from=builder /device-rest-go/LICENSE /
 COPY --from=builder /device-rest-go/Attribution.txt /
 
-EXPOSE 49986
+EXPOSE 59986
 
 ENTRYPOINT ["/device-rest"]
 CMD ["--cp=consul://edgex-core-consul:8500", "--confdir=/res", "--registry"]

--- a/README.md
+++ b/README.md
@@ -74,19 +74,19 @@ As with all device services the `device profile` is where the **Device Name**, *
 
 The best way to test this service with simulated data is to use **PostMan** to send data to the following endpoints defined for the above device profiles.
 
-- http://localhost:49986/api/v2/resource/sample-image/jpeg
+- http://localhost:59986/api/v2/resource/sample-image/jpeg
 
   - POSTing a JPEG binary image file will result in the `BinaryValue` of the `Reading` being set to the JPEG image data posted.
   - Example test JPEG to post:
     - Select any JPEG file from your computer or the internet
 
-- http://localhost:49986/api/v2/resource/sample-image/png
+- http://localhost:59986/api/v2/resource/sample-image/png
 
   - POSTing a PNG binary image file will result in the `BinaryValue` of the `Reading` being set to the PNG image data posted.
   - Example test PNG to post:
     - Select any PNG file from your computer or the internet
 
-- http://localhost:49986/api/v2/resource/sample-json/json
+- http://localhost:59986/api/v2/resource/sample-json/json
 
   - POSTing a JSON string value will result in the  `Value` of the `Reading` being set to the JSON string value posted.
 
@@ -102,7 +102,7 @@ The best way to test this service with simulated data is to use **PostMan** to s
     }
     ```
 
-- http://localhost:49986/api/v2/resource/sample-numeric/int
+- http://localhost:59986/api/v2/resource/sample-numeric/int
   - POSTing a text integer value will result in the  `Value` of the `Reading` being set to the string representation of the value as an `Int64`. The POSTed value is verified to be a valid `Int64` value. 
   
   - A 400 error will be returned if the POSTed value fails the `Int64` type verification.
@@ -113,7 +113,7 @@ The best way to test this service with simulated data is to use **PostMan** to s
     1001
     ```
   
-- http://localhost:49986/api/v2/resource/sample-numeric/float
+- http://localhost:59986/api/v2/resource/sample-numeric/float
   - POSTing a text float value will result in the  `Value` of the `Reading` being set to the string representation of the value as an `Float64`. The POSTed value is verified to be a valid `Float64` value. 
   
   - A 400 error will be returned if the POSTed value fails the `Float64` type verification.

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -13,7 +13,7 @@ BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
 ServerBindAddr = ''  # blank value defaults to Service.Host value
-Port = 49986
+Port = 59986
 Protocol = 'http'
 StartupMsg = 'REST device started'
 Timeout = 5000
@@ -32,12 +32,12 @@ Type = 'consul'
   [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48080
+  Port = 59880
 
   [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48081
+  Port = 59881
 
 [MessageQueue]
 Protocol = 'redis'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Ports assigned for Core/Supporting services are 408xx range
Device Rest uses 49986

## Issue Number: #102


## What is the new behavior?
Ports assigned for Core/Supporting services are 588xx range
Device rest default port number is now 59986

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Device Rest default port number has changed to 59986

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
