### PR TITLE
fix(snap): remove '-go' suffix from service name and update release name

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -29,5 +29,5 @@ $ sudo snap set edgex-device-rest startup-interval=1
 To apply the settings, the service should then be restarted as follows:
 
 ```bash
-$ sudo snap restart edgex-device-rest.device-rest-go
+$ sudo snap restart edgex-device-rest.device-rest
 ```

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,35 +9,35 @@ SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
 mkdir -p "$SNAP_DATA/config"
-if [ ! -f "$SNAP_DATA/config/device-rest-go/res/configuration.toml" ]; then
-    mkdir -p "$SNAP_DATA/config/device-rest-go/res"
-    cp "$SNAP/config/device-rest-go/res/configuration.toml" "$SNAP_DATA/config/device-rest-go/res/configuration.toml"
+if [ ! -f "$SNAP_DATA/config/device-rest/res/configuration.toml" ]; then
+    mkdir -p "$SNAP_DATA/config/device-rest/res"
+    cp "$SNAP/config/device-rest/res/configuration.toml" "$SNAP_DATA/config/device-rest/res/configuration.toml"
     # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON environment variables in the config files
     sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
         -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
         -e "s@\$SNAP@$SNAP_CURRENT@g" \
-        "$SNAP_DATA/config/device-rest-go/res/configuration.toml"
+        "$SNAP_DATA/config/device-rest/res/configuration.toml"
 fi
 
 # also copy the device profiles into $SNAP_DATA
-mkdir -p "$SNAP_DATA/config/device-rest-go/res/profiles"
-find "$SNAP/config/device-rest-go/res/profiles/" -type f -print | grep .yaml | \
+mkdir -p "$SNAP_DATA/config/device-rest/res/profiles"
+find "$SNAP/config/device-rest/res/profiles/" -type f -print | grep .yaml | \
      while read line; do
         fname=$(basename "$line")
-        if [ ! -f "$SNAP_DATA/config/device-rest-go/res/profiles/${fname}" ]; then
-            cp "$SNAP/config/device-rest-go/res/profiles/${fname}" \
-            "$SNAP_DATA/config/device-rest-go/res/profiles/${fname}"
+        if [ ! -f "$SNAP_DATA/config/device-rest/res/profiles/${fname}" ]; then
+            cp "$SNAP/config/device-rest/res/profiles/${fname}" \
+            "$SNAP_DATA/config/device-rest/res/profiles/${fname}"
         fi
     done
 
 # also copy the device into $SNAP_DATA
-mkdir -p "$SNAP_DATA/config/device-rest-go/res/devices"
-find "$SNAP/config/device-rest-go/res/devices/" -type f -print | grep .toml | \
+mkdir -p "$SNAP_DATA/config/device-rest/res/devices"
+find "$SNAP/config/device-rest/res/devices/" -type f -print | grep .toml | \
 
     while read line; do
         fname=$(basename "$line")
-        if [ ! -f "$SNAP_DATA/config/device-rest-go/res/devices/${fname}" ]; then
-            cp "$SNAP/config/device-rest-go/res/devices/${fname}" \
-            "$SNAP_DATA/config/device-rest-go/res/devices/${fname}"
+        if [ ! -f "$SNAP_DATA/config/device-rest/res/devices/${fname}" ]; then
+            cp "$SNAP/config/device-rest/res/devices/${fname}" \
+            "$SNAP_DATA/config/device-rest/res/devices/${fname}"
         fi
     done

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -3,4 +3,4 @@
 # save this revision for when we run again in the post-refresh
 snapctl set lastrev="$SNAP_REVISION"
 
-snapctl set release="geneva"
+snapctl set release="ireland"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,8 @@ apps:
       CONFIG_PRO_ARG: "--cp=consul://localhost:8500"
       CONF_ARG: "--confdir=$SNAP_DATA/config/device-rest/res"
       REGISTRY_ARG: "--registry"
-      DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-rest/res"
+      DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-rest/res/profiles"
+      DEVICE_DEVICESDIR: "$SNAP_DATA/config/device-rest/res/devices"
     plugs: [network, network-bind]
 
 parts:
@@ -64,11 +65,7 @@ parts:
 
       install -d "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/"
 
-      cat "./cmd/res/configuration.toml" | \
-        sed -e s:"'./device-rest.log'":"'\$SNAP_COMMON/device-rest.log'": \
-        -e s:"ProfilesDir = './res/profiles'":"ProfilesDir = '\$SNAP_DATA/config/device-rest/res/profiles'":  \
-        -e s:"DevicesDir = './res/devices'":"DevicesDir = '\$SNAP_DATA/config/device-rest/res/devices'": > \
-        "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/configuration.toml"
+      install -DT "./cmd/res/configuration.toml" "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/configuration.toml"
 
       for fpath in ./cmd/res/profiles/*.yaml; do
           fname=$(basename "$fpath")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,17 +22,17 @@ grade: stable
 confinement: strict
 
 apps:
-  device-rest-go:
+  device-rest:
     adapter: none
-    command: bin/device-rest-go $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
+    command: bin/device-rest $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
     command-chain:
       - bin/startup-env-var.sh
     daemon: simple
     environment:
       CONFIG_PRO_ARG: "--cp=consul://localhost:8500"
-      CONF_ARG: "--confdir=$SNAP_DATA/config/device-rest-go/res"
+      CONF_ARG: "--confdir=$SNAP_DATA/config/device-rest/res"
       REGISTRY_ARG: "--registry"
-      DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-rest-go/res"
+      DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-rest/res"
     plugs: [network, network-bind]
 
 parts:
@@ -48,7 +48,7 @@ parts:
       fi
       snapcraftctl set-version ${PROJECT_VERSION}
 
-  device-rest-go:
+  device-rest:
     source: .
     plugin: make
     build-packages: [git, libzmq3-dev, zip, pkg-config]
@@ -60,32 +60,32 @@ parts:
       go mod tidy
       make build
 
-      install -DT "./cmd/device-rest-go" "$SNAPCRAFT_PART_INSTALL/bin/device-rest-go"
+      install -DT "./cmd/device-rest" "$SNAPCRAFT_PART_INSTALL/bin/device-rest"
 
-      install -d "$SNAPCRAFT_PART_INSTALL/config/device-rest-go/res/"
+      install -d "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/"
 
       cat "./cmd/res/configuration.toml" | \
-        sed -e s:"'./device-rest-go.log'":"'\$SNAP_COMMON/device-rest-go.log'": \
-        -e s:"ProfilesDir = './res/profiles'":"ProfilesDir = '\$SNAP_DATA/config/device-rest-go/res/profiles'":  \
-        -e s:"DevicesDir = './res/devices'":"DevicesDir = '\$SNAP_DATA/config/device-rest-go/res/devices'": > \
-        "$SNAPCRAFT_PART_INSTALL/config/device-rest-go/res/configuration.toml"
+        sed -e s:"'./device-rest.log'":"'\$SNAP_COMMON/device-rest.log'": \
+        -e s:"ProfilesDir = './res/profiles'":"ProfilesDir = '\$SNAP_DATA/config/device-rest/res/profiles'":  \
+        -e s:"DevicesDir = './res/devices'":"DevicesDir = '\$SNAP_DATA/config/device-rest/res/devices'": > \
+        "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/configuration.toml"
 
       for fpath in ./cmd/res/profiles/*.yaml; do
           fname=$(basename "$fpath")
           install -DT "./cmd/res/profiles/${fname}" \
-          "$SNAPCRAFT_PART_INSTALL/config/device-rest-go/res/profiles/${fname}"
+          "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/profiles/${fname}"
       done
 
       for fpath in ./cmd/res/devices/*.toml; do
           fname=$(basename "$fpath")
           install -DT "./cmd/res/devices/${fname}" \
-          "$SNAPCRAFT_PART_INSTALL/config/device-rest-go/res/devices/${fname}"
+          "$SNAPCRAFT_PART_INSTALL/config/device-rest/res/devices/${fname}"
       done
 
       install -DT "./Attribution.txt" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-rest-go/Attribution.txt"
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-rest/Attribution.txt"
       install -DT "./LICENSE" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-rest-go/LICENSE"
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-rest/LICENSE"
 
   config-common:
     plugin: dump


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The snap currently doesn't build and install correctly, as it still expects the application to install to be
`./cmd/device-rest-go` and it's been renamed in the Makefile to `./cmd/device-rest`

## Issue Number:


## What is the new behavior?

- The service name is now device-rest, not device-rest-go. Starting the device is therefore now done with
 `sudo snap start edgex-device-rest.device-rest`

- The snap path has also changed accordingly
from `/var/snap/edgex-device-rest/current/config/device-rest-go/` to `/var/snap/edgex-device-rest/current/config/device-rest/`
- The version name is set to "Ireland" in the pre-refresh hook

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

BREAKING CHANGE: The snap service name has changed to device-camera

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
