### PR TITLE
fix: Remove retry items of SecretStore config and update secret path

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -58,13 +58,11 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/device-rest/'
+Path = 'device-rest/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/device-rest/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-rest-go
 go 1.16
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.70
+	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.71
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/cast v1.3.1


### PR DESCRIPTION
go-mod-bootstrap has implemented the addition of prefix /v1/secret/edgex/ for the Path property of SecretStore config section, so we just use the service specific secret path
        in Toml files

Fix: #111

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
old retry related items still in toml config and secret path is full path

## Issue Number:  #111 


## What is the new behavior?
Remove retry related item from toml configuration and use service specific path only

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
