### PR TITLE
fix(snap): create VERSION file during snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: edgex-device-rest
 base: core18
 type: app
-adopt-info: version
+adopt-info: device-rest
 license: Apache-2.0
 title: EdgeX REST Device Service
 summary: EdgeX device service for REST protocol
@@ -53,13 +53,6 @@ plugs:
     target: $SNAP_DATA/config/device-rest/res
 
 parts:
-  version:
-    plugin: nil
-    source: snap/local
-    override-pull: |
-      cd $SNAPCRAFT_PROJECT_DIR
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      snapcraftctl set-version ${GIT_VERSION}
 
   hooks:
     source: snap/local/hooks
@@ -81,6 +74,15 @@ parts:
     stage-packages: [libzmq5]
     override-build: |
       cd $SNAPCRAFT_PART_SRC
+
+      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
+      snapcraftctl set-version ${GIT_VERSION}
+      # this is needed for make build
+      echo $GIT_VERSION > ./VERSION
+
       go mod tidy
       make build
 


### PR DESCRIPTION
The makefile requires a VERSION file to be present when building the device service.

This commit creates the VERSION file using the current git tag
or alternatively falling back to using 0.0.0.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A because this is a snap-specific build change
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A because this is a snap-specific build change
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

1. Build the snap and verify that you see a valid version in

```
CGO_ENABLED=1 GO111MODULE=on go build -ldflags "-X github.com/edgexfoundry/device-rest-go.Version=2.0.1-dev.9" -o cmd/device-rest ./cmd
```

2. Test the REST endpoint at `curl http://localhost:59986/api/v2/version`


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->