### PR TITLE
build(snap): source metadata from central repo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,7 +81,7 @@ parts:
       # this is needed for make build
       echo $GIT_VERSION > ./VERSION
 
-      go mod tidy
+      go mod tidy -compat=1.17
       make build
 
       install -DT "./cmd/device-rest" "$SNAPCRAFT_PART_INSTALL/bin/device-rest"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,14 +1,8 @@
 name: edgex-device-rest
 base: core20
 type: app
-adopt-info: device-rest
 license: Apache-2.0
-title: EdgeX REST Device Service
-summary: EdgeX device service for REST protocol
-description: |
-  This device service provides easy way for 3'rd party applications, 
-  such as Point of Sale, CV Analytics, etc., to push data into EdgeX 
-  via the REST protocol.
+adopt-info: metadata
 
 # delhi: 0, edinburgh: 1, fuji: 2, geneva: 3, ireland: 4
 epoch: 4
@@ -64,6 +58,7 @@ parts:
       install -DT ./cmd/install/install "$SNAPCRAFT_PART_INSTALL/snap/hooks/install"
 
   device-rest:
+    after: [metadata]
     source: .
     plugin: make
     build-packages: [git, libzmq3-dev, zip, pkg-config]
@@ -73,13 +68,8 @@ parts:
     override-build: |
       cd $SNAPCRAFT_PART_SRC
 
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
-      # this is needed for make build
-      echo $GIT_VERSION > ./VERSION
+      # the version is needed for the build
+      cat ./VERSION
 
       go mod tidy -compat=1.17
       make build
@@ -103,3 +93,25 @@ parts:
     plugin: dump
     source: snap/local/runtime-helpers
 
+  metadata:
+    plugin: nil
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+      # change to this project's repo to get the version
+      cd $SNAPCRAFT_PROJECT_DIR
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+      # set the version of this snap
+      snapcraftctl set-version $VERSION
+    parse-info: [edgex-device-rest.metainfo.xml] 


### PR DESCRIPTION
The metadata kept in snapcraft.yaml is obsolete because it is being overridden on the store. This change will allow sourcing the central copy of metadata.

See https://github.com/canonical/edgex-snap-metadata/issues/2

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
# clean and build:
$ snapcraft clean && snapcraft

# unpack the built snap:
$ unsquashfs name.snap

# verify that icon exists:
$ ls squashfs-root/meta/gui/icon.png 
squashfs-root/meta/gui/icon.png

# verify that version, summary and description are included:
$ cat squashfs-root/meta/snap.yaml
...
version: 2.2.0-dev.8
summary: EdgeX Device REST
description: |-
  EdgeX Device REST is a device service which exposes RESTful endpoints for applications to push data into EdgeX over HTTP. This is useful for a variety of 3rd applications such as Point of Sale and CV Analytics allowing textual or binary data ingestion into EdgeX.

  **Snap usage instructions**

  https://github.com/edgexfoundry/device-rest-go/blob/main/snap/README.md

  **Source code and more info**

  https://github.com/edgexfoundry/device-rest-go

  **EdgeX documentation**

  https://docs.edgexfoundry.org

  **Reference platform snap**

  https://snapcraft.io/edgexfoundry
...
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->