### PR TITLE
feat(snap): use updated environment variable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -20,10 +20,13 @@ package main
 
 import (
 	"fmt"
-	hooks "github.com/canonical/edgex-snap-hooks/v2"
-	local "github.com/edgexfoundry/device-rest-go/hooks"
 	"os"
 	"strings"
+
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
+	local "github.com/edgexfoundry/device-rest-go/hooks"
 )
 
 var cli *hooks.CtlCli = hooks.NewSnapCtl()
@@ -95,6 +98,12 @@ func main() {
 		// no action necessary
 	default:
 		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
+		os.Exit(1)
+	}
+
+	log.SetComponentName("configure")
+	if err := options.ProcessAppConfig("device-rest"); err != nil {
+		hooks.Error(fmt.Sprintf("could not process options: %v", err))
 		os.Exit(1)
 	}
 }

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgexfoundry/device-rest-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5
 
 go 1.17
 

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgexfoundry/device-rest-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
 
 go 1.17
 

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgexfoundry/device-rest-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.1.1
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
 
 go 1.17
 

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5 h1:EDFjmHy8CG4T8uFPqD+Per8Hgk250PvRsMgEDCXjYtE=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b h1:vKrKzgdZo3kk0mptvQ1vvUUUQ2eYjE+nDMhT2tC9UJw=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.1.1 h1:qmDJ2RYd19I/NYwIdjqC/kWGVJWLcrT+h9NevB+Gz/A=
-github.com/canonical/edgex-snap-hooks/v2 v2.1.1/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b h1:vKrKzgdZo3kk0mptvQ1vvUUUQ2eYjE+nDMhT2tC9UJw=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
For details on the new scheme for setting environment variables, please refer to https://github.com/edgexfoundry/edgex-go/pull/3986.
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) N/A - they are in the imported module https://github.com/canonical/edgex-snap-testing/pull/53
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. set up:
```
snap install edgexfoundry --edge
snap install edgex-device-rest --channel="edge/pr-177"
```
2. Enable config and set a global config value:
```
$ snap set edgex-device-rest config-enabled=true
$ snap set edgex-device-rest config.service-startupmsg="testing injection"

$ snap start edgex-device-rest
Started.

$ snap logs -n=all edgex-device-rest | grep "testing injection"
...
```
3. Set a app-specific value:
```
$ snap set edgex-device-rest apps.device-rest.config.service-port=11111

$ snap restart edgex-device-rest
Restarted.

$ snap logs -n=all edgex-device-rest | grep "11111"
msg="Web server starting (localhost:11111)"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->