### PR TITLE
build(snap): Upgrade snap hook to 2.4.1

### DIFF
--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -41,7 +41,7 @@ var ConfToEnv = map[string]string{
 // configure is called by the main function
 func configure() {
 
-	const service = "device-rest"
+	const app = "device-rest"
 
 	log.SetComponentName("configure")
 
@@ -52,20 +52,20 @@ func configure() {
 	}
 	if envJSON != "" {
 		log.Debugf("envJSON: %s", envJSON)
-		err = hooks.HandleEdgeXConfig(service, envJSON, ConfToEnv)
+		err = hooks.HandleEdgeXConfig(app, envJSON, ConfToEnv)
 		if err != nil {
 			log.Fatalf("HandleEdgeXConfig failed: %v", err)
 		}
 	}
 
 	log.Info("Processing config options")
-	err = options.ProcessConfig(service)
+	err = options.ProcessConfig(app)
 	if err != nil {
 		log.Fatalf("could not process config options: %v", err)
 	}
 
 	log.Info("Processing autostart options")
-	err = options.ProcessAutostart(service)
+	err = options.ProcessAutostart(app)
 	if err != nil {
 		log.Fatalf("could not process autostart options: %v", err)
 	}

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -19,13 +19,9 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
 	"github.com/canonical/edgex-snap-hooks/v2/log"
 	"github.com/canonical/edgex-snap-hooks/v2/options"
-	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 )
 
 // ConfToEnv defines mappings from snap config keys to EdgeX environment variable
@@ -42,8 +38,6 @@ var ConfToEnv = map[string]string{
 	"device.use-message-bus":       "DEVICE_USEMESSAGEBUS",
 }
 
-var cli *hooks.CtlCli = hooks.NewSnapCtl()
-
 // configure is called by the main function
 func configure() {
 
@@ -51,49 +45,28 @@ func configure() {
 
 	log.SetComponentName("configure")
 
-	// read and handle config
-	envJSON, err := cli.Config(hooks.EnvConfig)
+	log.Info("Processing legacy env options")
+	envJSON, err := hooks.NewSnapCtl().Config(hooks.EnvConfig)
 	if err != nil {
 		log.Fatalf("Reading config 'env' failed: %v", err)
 	}
 	if envJSON != "" {
-		hooks.Debug(fmt.Sprintf("envJSON: %s", envJSON))
+		log.Debugf("envJSON: %s", envJSON)
 		err = hooks.HandleEdgeXConfig(service, envJSON, ConfToEnv)
 		if err != nil {
 			log.Fatalf("HandleEdgeXConfig failed: %v", err)
 		}
 	}
 
-	// If autostart is not explicitly set, default to "no"
-	// as only example service configuration and profiles
-	// are provided by default.
-	autostart, err := snapctl.Get("autostart").Run()
+	log.Info("Processing config options")
+	err = options.ProcessConfig(service)
 	if err != nil {
-		log.Fatalf("Reading config 'autostart' failed: %v", err)
-	}
-	if autostart == "" {
-		log.Debug("autostart is NOT set, initializing to 'no'")
-		autostart = "no"
-	}
-	autostart = strings.ToLower(autostart)
-	log.Debugf("autostart=%s", autostart)
-
-	// services are stopped/disabled by default in the install hook
-	switch autostart {
-	case "true", "yes":
-		err = snapctl.Start(service).Enable().Run()
-		if err != nil {
-			log.Fatalf("Can't start service: %s", err)
-		}
-	case "false", "no":
-		// no action necessary
-	default:
-		log.Fatalf("Invalid value for 'autostart': %s", autostart)
+		log.Fatalf("could not process config options: %v", err)
 	}
 
-	log.Info("Processing options")
-	err = options.ProcessAppConfig(service)
+	log.Info("Processing autostart options")
+	err = options.ProcessAutostart(service)
 	if err != nil {
-		log.Fatalf("could not process options: %v", err)
+		log.Fatalf("could not process autostart options: %v", err)
 	}
 }

--- a/snap/local/helper-go/go.mod
+++ b/snap/local/helper-go/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-rest-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.3.1
+require github.com/canonical/edgex-snap-hooks/v2 v2.4.1
 
 go 1.18

--- a/snap/local/helper-go/go.sum
+++ b/snap/local/helper-go/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.3.1 h1:6/wlpQGFB6nc293dk05UcpVrbDgnV74pR452DWP7bRM=
-github.com/canonical/edgex-snap-hooks/v2 v2.3.1/go.mod h1:8mjUKSAFNsXYvV0fcfOoYue1dSjTVeJYdaQYtA6pb6Y=
+github.com/canonical/edgex-snap-hooks/v2 v2.4.1 h1:TFFF/mHkYTmUd040N8S4q/mp78CUZr1W3Cxx4uRpfOg=
+github.com/canonical/edgex-snap-hooks/v2 v2.4.1/go.mod h1:8mjUKSAFNsXYvV0fcfOoYue1dSjTVeJYdaQYtA6pb6Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Use library function for autostart processing and config processing

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) [test suite](https://github.com/canonical/edgex-snap-testing/tree/main/test/suites/device-rest) passed with full config test enabled
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Install and setup:
```
snap install edgex-device-rest_2.3.0-dev.10_amd64.snap --devmode
snap install edgexfoundry
snap connect edgexfoundry:edgex-secretstore-token edgex-device-rest:edgex-secretstore-token
```
2. Validate that autostart works as expected:
```
$ snap set edgex-device-rest autostart=true
$ snap services edgex-device-rest
Service                        Startup  Current  Notes
edgex-device-rest.device-rest   enabled  active   -
$ snap logs edgex-device-rest -n=5
msg="Starting device-rest 2.3.0-dev.13 "
```
```
$ snap set edgex-device-rest autostart=false
$ snap services edgex-device-rest
Service                        Startup   Current   Notes
edgex-device-rest.device-rest   disabled  inactive  -
$ snap logs edgex-device-rest -n=5
Stopped Service for snap application edgex-device-rest.device-rest.
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->