### PR TITLE
refactor!: Clean up remain config items no longer needed

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -8,35 +8,9 @@ Port = 59986
 StartupMsg = "device rest started"
 
 [MessageBus]
-  [MessageBus.Topics]
-  PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
-  DeviceCommandRequestTopic = "edgex/device/command/request/device-rest/#"   # subscribing for inbound command requests
-  ResponseTopicPrefix = "edgex/response" # /<service-name>/<request-id> will be added to this prefix topic
   [MessageBus.Optional]
   # Default MQTT & NATS Specific options that need to be here to enable environment variable overrides of them
   ClientId = "device-rest"
-
-[SecretStore]
-Type = "vault"
-Host = "localhost"
-Port = 8200
-Path = "device-rest/"
-Protocol = "http"
-RootCaCertPath = ""
-ServerName = ""
-SecretsFile = ""
-DisableScrubSecretsFile = false
-TokenFile = "/tmp/edgex/secrets/device-rest/secrets-token.json"
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-  [SecretStore.RuntimeTokenProvider]
-  Enabled = false
-  Protocol = "https"
-  Host = "localhost"
-  Port = 59841
-  TrustDomain = "edgexfoundry.org"
-  EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
-  RequiredSecrets = "redisdb"
 
 # Driver configs
 [Driver]


### PR DESCRIPTION
BREAKING CHANGE: MessaegBus topics no longer in configuration except BaseTopixPrefix in common config. SecretProvider info no longer in configuartion. Replaced with defaults in code and environment variable overrides.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rest-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run make docker
Run secure Edgex Stack from compose builder
```
make run ds-rest device-dev
```
Verify Device Rest starts w/o error.
Verify Device Rest accepts async data and published to MessageBus successfully

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->